### PR TITLE
uthenticode: Clean verify_signature() up a bit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,4 @@ if(BUILD_TESTS)
   endif()
 
   add_subdirectory(test)
-  # add_executable(example example.cpp)
-  # target_link_libraries(example gtest_main)
-  # add_test(NAME example_test COMMAND example)
 endif()


### PR DESCRIPTION
Use our decoded structure instead of walking the PKCS#7 struct.