### PR TITLE
CMake: Add install target, CMake config exporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(uthenticode)
+
+# NOTE(ww): CMake has bad defaults for install prefixes.
+# Instead of fussing over them, install everything to the build directory by default
+# and let the user set CMAKE_INSTALL_PREFIX explicitly for their own needs.
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE PATH "Default install directory" FORCE)
+endif ()
+
 set(CMAKE_CXX_STANDARD 17)
 
 file(READ "${PROJECT_SOURCE_DIR}/VERSION" UTHENTICODE_VERSION)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ The rest of the build is standard CMake:
 $ mkdir build && cd build
 $ cmake ..
 $ cmake --build .
+# the default install prefix is the build directory;
+# use CMAKE_INSTALL_PREFIX to modify it
+$ cmake --build . --target install
 ```
 
 If you have `doxygen` installed, you can build *uthenticode*'s documentation with the top-level
@@ -63,7 +66,7 @@ $ make doc
 
 Pre-built (master) documentation is hosted [here](https://trailofbits.github.io/uthenticode/).
 
-Similarly, you can build the (gtest-based) unit tests with `-DBUILD_TESTS=1`.
+You can build the (gtest-based) unit tests with `-DBUILD_TESTS=1`.
 
 ## Usage
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,46 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   target_link_options("${PROJECT_NAME}" PUBLIC -fsanitize=address)
 endif()
 
-target_include_directories("${PROJECT_NAME}" PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_include_directories(
+    "${PROJECT_NAME}"
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+# NOTE(ww): More CMake dumbness: PUBLIC_HEADER doesn't get populated by
+# target_include_directories, even when set explicitly as PUBLIC.
+# We set it here so that it works correctly in the install step.
+set_target_properties(
+    "${PROJECT_NAME}"
+    PROPERTIES
+        PUBLIC_HEADER "include/uthenticode.h"
+)
 
 target_link_libraries("${PROJECT_NAME}" pe-parse::pe-parser-library)
 target_link_libraries("${PROJECT_NAME}" OpenSSL::Crypto)
+
+install(
+    TARGETS "${PROJECT_NAME}"
+    EXPORT uthenticode-config
+    RUNTIME
+        DESTINATION "bin"
+    LIBRARY
+        DESTINATION "lib"
+    ARCHIVE
+        DESTINATION "lib"
+    PUBLIC_HEADER
+        DESTINATION "include"
+)
+export(
+  TARGETS "${PROJECT_NAME}"
+  NAMESPACE uthenticode::
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/uthenticode-config.cmake"
+)
+install(
+  EXPORT
+  uthenticode-config
+  DESTINATION "lib/cmake/uthenticode"
+  NAMESPACE uthenticode::
+  EXPORT_LINK_INTERFACE_LIBRARIES
+)


### PR DESCRIPTION
Makes uthenticode easier to install and eventually package.