### PR TITLE
treewide: Add a Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build/
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND="noninteractive"
+RUN apt-get update && \
+  apt-get install -y apt-transport-https ca-certificates gnupg \
+    software-properties-common wget build-essential git libssl-dev && \
+  wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+    | gpg --dearmor - \
+    | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
+  apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' && \
+  apt-get update && \
+  apt-get install -y cmake
+
+WORKDIR /uthenticode
+
+ARG PEPARSE_VERSION
+RUN git clone --branch "${PEPARSE_VERSION}" \
+  https://github.com/trailofbits/pe-parse && \
+  mkdir -p pe-parse/build && \
+  cd pe-parse/build && \
+  cmake .. && make && make install
+
+ENV CMAKE_PREFIX_PATH=/uthenticode/pe-parse/build/lib/cmake/pe-parse

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ ALL_SRCS := $(shell find src test -type f \( -name '*.cpp' -o -name '*.h' \) -pr
 ALL_LISTFILES := $(shell find src test cmake -type f \( -name 'CMakeLists.txt' -o -name '*.cmake' \) -print)
 VERSION := $(shell cat VERSION)
 
+PEPARSE_VERSION ?= v1.2.0
+
 .PHONY: all
 all:
 	@echo "This Makefile does not build anything."
@@ -26,3 +28,7 @@ doc:
 	# Docs only: append the short hash to the version.
 	VERSION=$(VERSION)-$(shell git rev-parse --short HEAD) \
 		doxygen Doxyfile
+
+.PHONY: docker
+docker:
+	DOCKER_BUILDKIT=1 docker build -t uthenticode --build-arg PEPARSE_VERSION=$(PEPARSE_VERSION) .


### PR DESCRIPTION
This adds a Docker build, providing a consistent local build environment for development without requiring `vcpkg`.

Expected use:

```bash
$ make docker
$ docker run --rm -it -v $(pwd):/uthenticode/uthenticode uthenticode
```