### PR TITLE
Use modern CMake modules with OpenSSL dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ target_include_directories(
 set_target_properties("${PROJECT_NAME}" PROPERTIES PUBLIC_HEADER "include/uthenticode.h")
 
 target_link_libraries("${PROJECT_NAME}" PUBLIC pe-parse::pe-parser-library)
-target_link_libraries("${PROJECT_NAME}" PRIVATE "${OPENSSL_CRYPTO_LIBRARY}")
+target_link_libraries("${PROJECT_NAME}" PRIVATE OpenSSL::Crypto)
 
 # NOTE(ww): More CMake dumbness: linking to OpenSSL statically above apparently doesn't transitively
 # link pthread or libdl correctly. We fix them up here.


### PR DESCRIPTION
Testing CMake changes for OpenSSL after some build issues with `vcpkg` and Visual Studio integration on Windows