### PR TITLE
Add cmake flag to use system gtest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ endif()
 
 # gtest setup. Adapted roughly from the googletest README.
 if(BUILD_TESTS)
+  option(USE_SYSTEM_GTEST "Use the system-installed Google Test library rather than downloading and building it" OFF)
   if(NOT USE_SYSTEM_GTEST)
     set(gtest_cmake_in "${CMAKE_CURRENT_SOURCE_DIR}/cmake/gtest.cmake.in")
     set(gtest_cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,45 +29,47 @@ endif()
 
 # gtest setup. Adapted roughly from the googletest README.
 if(BUILD_TESTS)
-  set(gtest_cmake_in "${CMAKE_CURRENT_SOURCE_DIR}/cmake/gtest.cmake.in")
-  set(gtest_cmake
-      "${CMAKE_CURRENT_BINARY_DIR}/googletest-download/CMakeLists.txt")
-  configure_file("${gtest_cmake_in}" "${gtest_cmake}")
+  if(NOT USE_SYSTEM_GTEST)
+    set(gtest_cmake_in "${CMAKE_CURRENT_SOURCE_DIR}/cmake/gtest.cmake.in")
+    set(gtest_cmake
+        "${CMAKE_CURRENT_BINARY_DIR}/googletest-download/CMakeLists.txt")
+    configure_file("${gtest_cmake_in}" "${gtest_cmake}")
 
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-    RESULT_VARIABLE result
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+      RESULT_VARIABLE result
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
 
-  if(result)
-    message(FATAL_ERROR "CMake step for googletest failed: ${result}")
-  endif()
+    if(result)
+      message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+    endif()
 
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} --build .
-    RESULT_VARIABLE result
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} --build .
+      RESULT_VARIABLE result
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
 
-  if(result)
-    message(FATAL_ERROR "Build step for googletest failed: ${result}")
-  endif()
+    if(result)
+      message(FATAL_ERROR "Build step for googletest failed: ${result}")
+    endif()
 
-  # Prevent overriding the parent project's compiler/linker settings on Windows
-  set(gtest_force_shared_crt
-      ON
-      CACHE BOOL "" FORCE)
+    # Prevent overriding the parent project's compiler/linker settings on Windows
+    set(gtest_force_shared_crt
+        ON
+        CACHE BOOL "" FORCE)
 
-  # Add googletest directly to our build. This defines the gtest and gtest_main
-  # targets.
-  add_subdirectory(
-    ${CMAKE_CURRENT_BINARY_DIR}/googletest-src
-    ${CMAKE_CURRENT_BINARY_DIR}/googletest-build EXCLUDE_FROM_ALL)
+    # Add googletest directly to our build. This defines the gtest and gtest_main
+    # targets.
+    add_subdirectory(
+      ${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+      ${CMAKE_CURRENT_BINARY_DIR}/googletest-build EXCLUDE_FROM_ALL)
 
-  # The gtest/gtest_main targets carry header search path dependencies
-  # automatically when using CMake 2.8.11 or later. Otherwise we have to add
-  # them here ourselves.
-  if(CMAKE_VERSION VERSION_LESS 2.8.11)
-    include_directories("${gtest_SOURCE_DIR}/include")
+    # The gtest/gtest_main targets carry header search path dependencies
+    # automatically when using CMake 2.8.11 or later. Otherwise we have to add
+    # them here ourselves.
+    if(CMAKE_VERSION VERSION_LESS 2.8.11)
+      include_directories("${gtest_SOURCE_DIR}/include")
+    endif()
   endif()
 
   add_subdirectory(test)


### PR DESCRIPTION
This allows to use already built gtest by supplying a cmake flag. Doesn't change the current build.