### PR TITLE
Fix: find GTest when USE_EXTERNAL_GTEST

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ if(BUILD_TESTS)
     if(CMAKE_VERSION VERSION_LESS 2.8.11)
       include_directories("${gtest_SOURCE_DIR}/include")
     endif()
+  else()
+    find_package(GTest CONFIG REQUIRED)
   endif()
 
   add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ endif()
 
 # gtest setup. Adapted roughly from the googletest README.
 if(BUILD_TESTS)
-  option(USE_SYSTEM_GTEST "Use the system-installed Google Test library rather than downloading and building it" OFF)
-  if(NOT USE_SYSTEM_GTEST)
+  option(USE_EXTERNAL_GTEST "Advanced use only. Use an external Google Test library rather than downloading and building it" OFF)
+  if(NOT USE_EXTERNAL_GTEST)
     set(gtest_cmake_in "${CMAKE_CURRENT_SOURCE_DIR}/cmake/gtest.cmake.in")
     set(gtest_cmake
         "${CMAKE_CURRENT_BINARY_DIR}/googletest-download/CMakeLists.txt")
@@ -72,6 +72,7 @@ if(BUILD_TESTS)
       include_directories("${gtest_SOURCE_DIR}/include")
     endif()
   else()
+    message(WARNING "It is STRONGLY recommended to *NOT* set USE_EXTERNAL_GTEST unless you know how to debug build systems and dependencies")
     find_package(GTest CONFIG REQUIRED)
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 
 # gtest setup. Adapted roughly from the googletest README.
 if(BUILD_TESTS)
-  option(USE_EXTERNAL_GTEST "Advanced use only. Use an external Google Test library rather than downloading and building it" OFF)
+  option(USE_EXTERNAL_GTEST "Advanced use only. Use an external GoogleTest library rather than downloading and building it" OFF)
   if(NOT USE_EXTERNAL_GTEST)
     set(gtest_cmake_in "${CMAKE_CURRENT_SOURCE_DIR}/cmake/gtest.cmake.in")
     set(gtest_cmake

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,11 @@ file(
 
 add_executable("${PROJECT_NAME}" ${UTHENTICODE_TEST_SOURCES})
 add_test(NAME "${PROJECT_NAME}" COMMAND "${PROJECT_NAME}")
-target_link_libraries("${PROJECT_NAME}" PUBLIC uthenticode gtest)
+if (NOT USE_SYSTEM_GTEST)
+  target_link_libraries("${PROJECT_NAME}" PUBLIC uthenticode gtest)
+else ()
+  target_link_libraries("${PROJECT_NAME}" PUBLIC uthenticode GTest::gtest)
+endif ()
 target_compile_definitions(
   "${PROJECT_NAME}" PRIVATE UTHENTICODE_TEST_ASSETS="${CMAKE_CURRENT_SOURCE_DIR}/assets"
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ file(
 
 add_executable("${PROJECT_NAME}" ${UTHENTICODE_TEST_SOURCES})
 add_test(NAME "${PROJECT_NAME}" COMMAND "${PROJECT_NAME}")
-if (NOT USE_SYSTEM_GTEST)
+if (NOT USE_EXTERNAL_GTEST)
   target_link_libraries("${PROJECT_NAME}" PUBLIC uthenticode gtest)
 else ()
   target_link_libraries("${PROJECT_NAME}" PUBLIC uthenticode GTest::gtest)


### PR DESCRIPTION
This only works on some of the latest releases of googletest, since
previously the name passed to find_package was different.

Adding this is still better than not, since previously it will always
fail if trying to compile tests with -DUSE_EXTERNAL_GTEST=ON

Renames `USE_SYSTEM_GTEST` to `USE_EXTERNAL_GTEST`,
since `GTest` could come from anywhere, not necessarily
system-installed location.

Improves upon #40 