### PR TITLE
Adapt pe-parse include path, remove legacy CMake target name

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,15 +30,7 @@ target_include_directories(
 # even when set explicitly as PUBLIC. We set it here so that it works correctly in the install step.
 set_target_properties("${PROJECT_NAME}" PROPERTIES PUBLIC_HEADER "include/uthenticode.h")
 
-# Newer versions of pe-parse use the `pe-parse` target. This check should be removed once the
-# releases on vcpkg stabilize.
-if (TARGET pe-parse::pe-parse)
-  target_link_libraries("${PROJECT_NAME}" PUBLIC pe-parse::pe-parse)
-else ()
-  target_link_libraries("${PROJECT_NAME}" PUBLIC pe-parse::pe-parser-library)
-endif ()
-
-target_link_libraries("${PROJECT_NAME}" PUBLIC OpenSSL::Crypto)
+target_link_libraries("${PROJECT_NAME}" PUBLIC pe-parse::pe-parse OpenSSL::Crypto)
 
 install(
   TARGETS "${PROJECT_NAME}"

--- a/src/include/uthenticode.h
+++ b/src/include/uthenticode.h
@@ -4,7 +4,7 @@
 #include <openssl/asn1t.h>
 #include <openssl/crypto.h>
 #include <openssl/x509.h>
-#include <parser-library/parse.h>
+#include <pe-parse/parse.h>
 
 #include <cstdint>
 #include <exception>

--- a/test/certificate-test.cpp
+++ b/test/certificate-test.cpp
@@ -1,4 +1,4 @@
-#include <parser-library/parse.h>
+#include <pe-parse/parse.h>
 #include <uthenticode.h>
 
 #include <cstdlib>

--- a/test/signeddata-test.cpp
+++ b/test/signeddata-test.cpp
@@ -1,4 +1,4 @@
-#include <parser-library/parse.h>
+#include <pe-parse/parse.h>
 #include <uthenticode.h>
 
 #include <cstdlib>

--- a/test/uthenticode-test.cpp
+++ b/test/uthenticode-test.cpp
@@ -1,4 +1,4 @@
-#include <parser-library/parse.h>
+#include <pe-parse/parse.h>
 #include <uthenticode.h>
 
 #include <cstdlib>

--- a/test/wincert-test.cpp
+++ b/test/wincert-test.cpp
@@ -1,4 +1,4 @@
-#include <parser-library/parse.h>
+#include <pe-parse/parse.h>
 #include <uthenticode.h>
 
 #include <cstdlib>


### PR DESCRIPTION
The latest versions of pe-parse use the include path `pe-parse` instead of `parser-library`. This project claims to be compatible to the latest pe-parse but is still using the old include path. This fixes it.