### PR TITLE
Since OpenSSL 3 sk_X509_free is implemented as macro

### DIFF
--- a/src/include/uthenticode.h
+++ b/src/include/uthenticode.h
@@ -48,6 +48,7 @@ DECLARE_ASN1_FUNCTIONS(Authenticode_SpcIndirectDataContent)
  * So we wrap it here for use with unique_ptr.
  */
 void OpenSSL_free(void *ptr);
+void SK_X509_free(stack_st_X509 *ptr);
 
 /* Convenient self-releasing aliases for libcrypto and custom ASN.1 types.
  */
@@ -56,7 +57,7 @@ using ASN1_OBJECT_ptr = std::unique_ptr<ASN1_OBJECT, decltype(&ASN1_OBJECT_free)
 using ASN1_TYPE_ptr = std::unique_ptr<ASN1_TYPE, decltype(&ASN1_TYPE_free)>;
 using OpenSSL_ptr = std::unique_ptr<char, decltype(&OpenSSL_free)>;
 using BN_ptr = std::unique_ptr<BIGNUM, decltype(&BN_free)>;
-using STACK_OF_X509_ptr = std::unique_ptr<STACK_OF(X509), decltype(&sk_X509_free)>;
+using STACK_OF_X509_ptr = std::unique_ptr<STACK_OF(X509), decltype(&SK_X509_free)>;
 
 using SectionList = std::vector<const peparse::bounded_buffer *>;
 

--- a/src/include/uthenticode.h
+++ b/src/include/uthenticode.h
@@ -48,6 +48,10 @@ DECLARE_ASN1_FUNCTIONS(Authenticode_SpcIndirectDataContent)
  * So we wrap it here for use with unique_ptr.
  */
 void OpenSSL_free(void *ptr);
+
+/* Since OpenSSL 3.0.0 SK_X509_free is defined as a macro, which we can't use with decltype.
+ * So we wrap it here for use with unique_ptr.
+ */
 void SK_X509_free(stack_st_X509 *ptr);
 
 /* Convenient self-releasing aliases for libcrypto and custom ASN.1 types.

--- a/src/uthenticode.cpp
+++ b/src/uthenticode.cpp
@@ -39,6 +39,11 @@ IMPLEMENT_ASN1_FUNCTIONS(Authenticode_SpcIndirectDataContent)
 void OpenSSL_free(void *ptr) {
   OPENSSL_free(ptr);
 }
+
+void SK_X509_free(stack_st_X509 *ptr) {
+  sk_X509_free(ptr);
+}
+
 // clang-format on
 }  // namespace impl
 
@@ -255,7 +260,7 @@ std::vector<Certificate> SignedData::get_signers() const {
   if (signers_stack_ptr == nullptr) {
     return {};
   }
-  auto signers_stack = impl::STACK_OF_X509_ptr(signers_stack_ptr, sk_X509_free);
+  auto signers_stack = impl::STACK_OF_X509_ptr(signers_stack_ptr, impl::SK_X509_free);
 
   std::vector<Certificate> signers;
   for (auto i = 0; i < sk_X509_num(signers_stack.get()); ++i) {


### PR DESCRIPTION
I wrapped `sk_X509_free` in a function called `SK_X509_free`.
