### PR TITLE
src/uthenticode.cpp: add missing <utility> include

### DIFF
--- a/src/uthenticode.cpp
+++ b/src/uthenticode.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <memory>
 #include <sstream>
+#include <utility>
 
 namespace uthenticode {
 namespace impl {


### PR DESCRIPTION
Without the change build fails on upcoming gcc-13 as:

    [ 12%] Building CXX object uthenticode.cpp.o
    src/uthenticode.cpp: In constructor 'uthenticode::SignedData::SignedData(uthenticode::SignedData&&)':
    src/uthenticode.cpp:177:16: error: 'exchange' is not a member of 'std'
      177 |       p7_(std::exchange(s.p7_, nullptr)),
          |                ^~~~~~~~