### PR TITLE
fixed bug where sections ended up in a copy

### DIFF
--- a/src/uthenticode.cpp
+++ b/src/uthenticode.cpp
@@ -581,9 +581,9 @@ std::optional<std::string> calculate_checksum(peparse::parsed_pe *pe, checksum_k
     uint32_t total_bytes_hashed;
   };
 
-  impl::SectionList sections;
-  uint32_t total_bytes_hashed = size_of_headers;
-  iter_sec_ctx ctx = {sections, total_bytes_hashed};
+  iter_sec_ctx ctx = {};
+  ctx.total_bytes_hashed = size_of_headers;
+
 
   /* Build up the list of sections in the PE, in ascending order by PointerToRawData
    * (i.e., by file offset).
@@ -605,9 +605,11 @@ std::optional<std::string> calculate_checksum(peparse::parsed_pe *pe, checksum_k
       },
       &ctx);
 
+  uint32_t total_bytes_hashed = ctx.total_bytes_hashed;
+
   /* Copy each section's data into pe_bits, in ascending order.
    */
-  for (const auto &section : sections) {
+  for (const auto &section : ctx.sections) {
     pe_bits.insert(pe_bits.end(), section->buf, section->buf + section->bufLen);
   }
 


### PR DESCRIPTION
In `calculate_checksum` we iterate over the list of sections.
However, instead of populating the local sections vector we populate `ctx.sections` instead.
`for (const auto &section : sections)` then ends up iterating over a empty vector.

This behavior has likely gone unnoticed because `total_bytes_hashed` was also a copy, which caused the sections we missed before to end up in the `trailer_buf` instead. 
This combination of bugs causes it to hash correctly.

Another thing worth mentioning is that according to the authenticode spec the sections should be hashed in order of their base address. which is something i don't think we currently do.

