### PR TITLE
build: use cmake presets, simplify vcpkg integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,6 @@ on:
       - master
   pull_request:
 
-env:
-  vcpkg-commit: 9d47b24eacbd1cd94f139457ef6cd35e5d92cc84
-
 jobs:
   build-linux:
     strategy:
@@ -26,8 +23,6 @@ jobs:
 
       - name: Restore from cache and install vcpkg
         uses: lukka/run-vcpkg@v11
-        with:
-          vcpkgGitCommitId: ${{ env.vcpkg-commit }}
 
       - name: deps
         run: |
@@ -65,8 +60,6 @@ jobs:
 
       - name: Restore from cache and install vcpkg
         uses: lukka/run-vcpkg@v11
-        with:
-          vcpkgGitCommitId: ${{ env.vcpkg-commit }}
 
       - name: configure
         run: |
@@ -101,8 +94,6 @@ jobs:
 
       - name: Restore from cache and install vcpkg
         uses: lukka/run-vcpkg@v11
-        with:
-          vcpkgGitCommitId: ${{ env.vcpkg-commit }}
 
       - name: configure
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,18 +36,17 @@ jobs:
 
       - name: configure
         run: |
-          mkdir build && cd build
           cmake \
-            -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+            -B build \
+            -S . \
+            --preset default \
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
             -DBUILD_SHARED_LIBS=${{ matrix.build-shared.flag }} \
             -DBUILD_SVCLI=1 \
-            -DBUILD_TESTS=1 \
-            ..
+            -DBUILD_TESTS=1
 
       - name: build
-        working-directory: build
-        run: cmake --build .
+        run: cmake --build build
 
       - name: tests
         working-directory: build
@@ -71,18 +70,17 @@ jobs:
 
       - name: configure
         run: |
-          mkdir build && cd build
           cmake \
-            -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+            -B build \
+            -S . \
+            --preset default \
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
             -DBUILD_SHARED_LIBS=${{ matrix.build-shared.flag }} \
             -DBUILD_SVCLI=1 \
-            -DBUILD_TESTS=1 \
-            ..
+            -DBUILD_TESTS=1
 
       - name: build
-        working-directory: build
-        run: cmake --build .
+        run: cmake --build build
 
       - name: tests
         working-directory: build
@@ -109,19 +107,18 @@ jobs:
       - name: configure
         shell: bash
         run: |
-          mkdir build
-          cd build
           cmake \
             -G "Visual Studio 17 2022" \
             -A ${{ matrix.build-arch.arch }} \
-            -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+            -B build \
+            -S . \
+            --preset default \
             -DBUILD_SVCLI=1 \
             -DBUILD_TESTS=1 \
             ..
 
       - name: build
-        working-directory: build
-        run: cmake --build . --config ${{ matrix.build-type }}
+        run: cmake --build build --config ${{ matrix.build-type }}
 
       - name: tests
         working-directory: build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: lukka/get-cmake@latest
+
       - name: Restore from cache and install vcpkg
         uses: lukka/run-vcpkg@v11
 
@@ -58,6 +60,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: lukka/get-cmake@latest
+
       - name: Restore from cache and install vcpkg
         uses: lukka/run-vcpkg@v11
 
@@ -91,6 +95,8 @@ jobs:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.build-arch.triplet }}
     steps:
       - uses: actions/checkout@v4
+
+      - uses: lukka/get-cmake@latest
 
       - name: Restore from cache and install vcpkg
         uses: lukka/run-vcpkg@v11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(uthenticode)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,12 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -52,8 +52,12 @@ complete.
 and OpenSSL 3.0 or higher, which are installed via `vcpkg` by following these steps:
 
 ```bash
+# or set this in your shell environment/profile
+export VCPKG_ROOT=/path/to/vcpkg
+
 cmake -B build -S . --preset default
 cmake --build build
+
 # the default install prefix is the build directory;
 # use CMAKE_INSTALL_PREFIX to modify it
 cmake --build build --target install

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ complete.
 and OpenSSL 3.0 or higher, which are installed via `vcpkg` by following these steps:
 
 ```bash
-cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=<vcpkg-path>/scripts/buildsystems/vcpkg.cmake
+cmake -B build -S . --preset default
 cmake --build build
 # the default install prefix is the build directory;
 # use CMAKE_INSTALL_PREFIX to modify it

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(uthenticode)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
     "name": "uthenticode",
     "version-semver": "1.0.9",
+    "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf",
     "dependencies": [
         "pe-parse",
         "openssl"


### PR DESCRIPTION
This makes our build a bit more idiomatic, and fixes the macOS CI in the process.

Signed-off-by: William Woodruff <william@trailofbits.com>